### PR TITLE
Add NuGet package update schedule to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
    directory: "/"
    schedule:
      interval: daily
+
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This pull request adds a daily update schedule for NuGet packages in the dependabot.yml file. This ensures that the project's dependencies are regularly updated to the latest versions.